### PR TITLE
upgrade dependencies

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,11 +1,2 @@
-[target.thumbv7m-none-eabi]
-runner = 'arm-none-eabi-gdb'
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
-  "-Z", "thinlto=no",
-]
-
 [build]
 target = "thumbv7m-none-eabi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,17 @@ repository = "https://github.com/ah-/stm32l151-hal"
 version = "0.3.0"
 
 [dependencies]
-cortex-m = "0.5.6"
+cortex-m = "0.5.7"
 nb = "0.1.1"
 
 [dependencies.stm32l1]
 features = ["stm32l151", "rt"]
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.5.3"
+version = "0.6.4"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.1.0"
+version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["arm", "cortex-m", "stm32", "hal"]
 license = "MIT OR Apache-2.0"
 name = "stm32l151-hal"
 repository = "https://github.com/ah-/stm32l151-hal"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 cortex-m = "0.5.7"

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -129,14 +129,6 @@ macro_rules! gpio {
                 }
 
                 impl OutputPin for $PXi<Output> {
-                    fn is_high(&self) -> bool {
-                        !self.is_low()
-                    }
-
-                    fn is_low(&self) -> bool {
-                        unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 }
-                    }
-
                     fn set_high(&mut self) {
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) }
                     }


### PR DESCRIPTION
embedded-hal 0.2 removes 2 methods, which makes this a version-bump. However anne-key doesn't use those methods.

I have also removed the linker config, as those belong in anne-key the application. This also removes requirement on arm-gcc.