### PR TITLE
upgrade stm32l1 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["arm", "cortex-m", "stm32", "hal"]
 license = "MIT OR Apache-2.0"
 name = "stm32l151-hal"
 repository = "https://github.com/ah-/stm32l151-hal"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 cortex-m = "0.5.7"
@@ -14,7 +14,7 @@ nb = "0.1.1"
 
 [dependencies.stm32l1]
 features = ["stm32l151", "rt"]
-version = "0.2.3"
+version = "0.3.2"
 
 [dependencies.cortex-m-rt]
 optional = true


### PR DESCRIPTION
I have my doubt about stm32l1. I think you should release -hal 0.4 before merging this in as 0.5, so that we can fallback to stm32l1 0.2 if need be.