### PR TITLE
bump dependencies (bigger)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,20 +6,20 @@ keywords = ["arm", "cortex-m", "stm32", "hal"]
 license = "MIT OR Apache-2.0"
 name = "stm32l151-hal"
 repository = "https://github.com/ah-/stm32l151-hal"
-version = "0.5.0"
+version = "0.8.0"
 
 [dependencies]
-cortex-m = "0.5.7"
-nb = "0.1.1"
+cortex-m = "0.6.1"
+nb = "0.1.2"
 
 [dependencies.stm32l1]
 features = ["stm32l151", "rt"]
-version = "0.3.2"
+version = "0.8.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.6.4"
+version = "0.6.10"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.1"
+version = "0.2.3"

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -15,7 +15,7 @@ macro_rules! gpio {
         pub mod $gpiox {
             use core::marker::PhantomData;
 
-            use hal::digital::{InputPin, OutputPin};
+            use crate::hal::digital::{InputPin, OutputPin};
             use stm32l1::stm32l151::$GPIOX;
 
             use super::{Alternate, GpioExt, Input, Output};

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -15,7 +15,7 @@ macro_rules! gpio {
         pub mod $gpiox {
             use core::marker::PhantomData;
 
-            use crate::hal::digital::{InputPin, OutputPin};
+            use crate::hal::digital::v2::{InputPin, OutputPin};
             use stm32l1::stm32l151::$GPIOX;
 
             use super::{Alternate, GpioExt, Input, Output};
@@ -119,22 +119,26 @@ macro_rules! gpio {
                 }
 
                 impl InputPin for $PXi<Input> {
-                    fn is_high(&self) -> bool {
-                        !self.is_low()
+                    type Error = core::convert::Infallible;
+
+                    fn is_high(&self) -> Result<bool, Self::Error> {
+                        self.is_low().map(|v| !v)
                     }
 
-                    fn is_low(&self) -> bool {
-                        unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 }
+                    fn is_low(&self) -> Result<bool, Self::Error> {
+                        Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 })
                     }
                 }
 
                 impl OutputPin for $PXi<Output> {
-                    fn set_high(&mut self) {
-                        unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) }
+                    type Error = core::convert::Infallible;
+
+                    fn set_high(&mut self) -> Result<(), Self::Error> {
+                        Ok(unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) })
                     }
 
-                    fn set_low(&mut self) {
-                        unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + $i))) }
+                    fn set_low(&mut self) -> Result<(), Self::Error> {
+                        Ok(unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + $i))) })
                     }
                 }
             )+


### PR DESCRIPTION
also use the same version number as stm32l1

This will clear up embedded-hal deprecation warnings, however anne-key will need to be modified extensively due to USB and HAL rearrangement